### PR TITLE
Add Octavia and extend service discovery

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -53,15 +53,17 @@ class TempestRequest(object):
     def target(self):
         if self.url.port == 9696:
             return 'Neutron'
-        elif self.url.path.startswith('/compute'):
+        elif self.url.path.startswith('/compute') or self.url.port in {8773, 8774, 8775}:
             return 'Nova'
-        elif self.url.path.startswith('/identity'):
+        elif self.url.path.startswith('/identity') or self.url.port in {5000, 35357}:
             return 'Keystone'
-        elif self.url.path.startswith('/volume'):
+        elif self.url.path.startswith('/volume') or self.url.port == 8776:
             return 'Cinder'
-        elif self.url.path.startswith('/image'):
+        elif self.url.path.startswith('/image') or self.url.port == 9292:
             return 'Glance'
-        return self.url.hostname
+        elif self.url.port == 9876:
+            return 'Octavia'
+        return "{}.{}".format(self.url.hostname, self.url.port)
 
     @classmethod
     def from_lines(cls, info, debug):


### PR DESCRIPTION
This patch adds support for Octavia on port 9876. It also extends
service discovery by looking up for the IP port [1] in addition to URL
path. For unknown services, the diagram will now also include the host port.

[1] https://docs.openstack.org/install-guide/firewalls-default-ports.html